### PR TITLE
Removes use of jQuery library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
   * No static html, css, or js files
   * Demonstrates how to generate and manipulate html in pure python on both the client and server sides.
-  * A useful skeleton that include Ajax JSON state updates from server to client and vice versa.
-  * Uses a little jQuery on the client side (hence the 'nearly' in Nearly Pure)
+  * A useful skeleton that includes Ajax JSON state updates from server to client and vice versa.
+  * Calls a few JS methods directly from Python, hence the 'nearly pure' in the title
   * Powered by Jacques De Hooge's [*Transcrypt™*](https://transcrypt.org/) Python to JS transpiler and Marcel Hellkamp's [*Bottle Python Web Framework.*](http://bottlepy.org/docs/dev/)
 
 ### Who's this for?
@@ -30,6 +30,8 @@
     cd NearlyPurePythonWebAppDemo
     python server.py
   ```
+  * Note: You can choose a different server and port. Do `python server.py -h` for details
+
   * browse to http://localhost:8800 . Your should see a screen like the one below with readout values updating every half-second. Values are color coded as follows:
     * blue:  V <= 2.0 : blue
     * green: 2.0 < V < 8.0 : green
@@ -39,6 +41,7 @@
     * Larger values cause faster drifts through color ranges.
 
   ![Figure 1.](doc/img/nppwad.gif)
+
 
 ### Files
 Here's what comes from the repository:
@@ -90,4 +93,4 @@ If you're already comfortable in Python and understand what goes on in a browser
 <hr>
 Footnotes
 
-<a name="hint">1</a>: Biochemical assistance may be required. ;-)
+<a name="hint">1</a>: Neuro-chemical assistance may be required. ;-)

--- a/client.py
+++ b/client.py
@@ -12,13 +12,12 @@ Author: Mike Ellis
 Copyright 2017 Ellis & Grant, Inc.
 License: MIT License
 """
-#__pragma__ ('alias', 'jq', '$')
 
 import common
 from htmltree import Element as E
 
 _state = None
-_jq_readouts = None
+_readouts = None
 
 def makeBody():
     """
@@ -50,14 +49,78 @@ def makeBody():
     ## Use the DOM API to insert rendered content
     document.body.innerHTML = bodycontent.render()
 
+#########################################################
+# jQuery replacement functions
+# The next 3 function could logically be placed in a
+# separate module.
+#########################################################
+def triggerCustomEvent(name, data):
+    """
+    JS version of jQuery.trigger.
+    see  http://youmightnotneedjquery.com/#trigger_custom
+    """
+    if window.CustomEvent:
+        event = __new__ (CustomEvent(name, {'detail' : data}))
+    else:
+        event = document.createEvent('CustomEvent')
+        event.initCustomEvent(name, True, True, data)
+    document.dispatchEvent(event)
+
+def getJSON(url, f):
+    """
+    JS version of jQuery.getJSON
+    see http://youmightnotneedjquery.com/#get_json
+    url must return a JSON string
+    f(data) handles an object parsed from the return JSON string
+    """
+    request = __new__ (XMLHttpRequest())
+    request.open('GET', url, True)
+    def onload():
+        if 200 <= request.status < 400:
+            data = JSON.parse(request.responseText)
+            f(data) ## call handler with object created from JSON string
+        else:
+            _ = "Server returned {} for getJSON request on {}".format(request.status, url)
+            console.log(_)
+    def onerror():
+        _ = "Connection error for getJSON request on {}".format(url)
+        console.log(_)
+    request.onload = onload
+    request.onerror = onerror
+    request.send()
+
+def post(url, data):
+    """
+    JS version of jQuery.post
+    see http://youmightnotneedjquery.com/#post
+    data is expected to be a dict.
+    """
+    request = __new__(XMLHttpRequest())
+    request.open('POST', url, True)
+    request.setRequestHeader('Content-Type',
+                             'application/x-www-form-urlencoded; '
+                             'charset=UTF-8')
+    ## serialize the data, see http://stackoverflow.com/a/1714899/426853
+    ldata = []
+    for k,v in data.items():
+        if data.hasOwnProperty(k):
+            lh = encodeURIComponent(k)
+            rh = encodeURIComponent(v)
+            ldata.append("{}={}".format(lh, rh))
+
+    request.send("&".join(ldata))
+
+# End of j!uery replacement functions
+########################################################
+
 def getState():
     """ Fetch JSON obj containing monitored variables. """
     def f(data):
         global _state
         _state = data
-        jq(document).trigger('state:update')
+        triggerCustomEvent('state:update', {})
         #console.log(_state)
-    jq.getJSON('/getstate', f)
+    getJSON('/getstate', f)
     return
 
 def update_readouts():
@@ -67,9 +130,8 @@ def update_readouts():
     """
     ## queue the new values and colora
     queue = []
-    for el in _jq_readouts:
-        jq_el = jq(el)
-        key = jq_el.attr('data-key')
+    for el in _readouts:
+        key = el.getAttribute('data-key')
         value = _state[key]
         valuef = float(value)
         if valuef <= 2.0:
@@ -78,14 +140,19 @@ def update_readouts():
             color = 'red'
         else:
             color = 'green'
-        queue.append((jq_el, value, color))
+        queue.append((el, value, color))
 
     ## write them to the DOM
-    for jq_el, value, color in queue:
-        jq_el.text(value).attr('style', "color:{}; font-size:32;".format(color))
+    for el, value, color in queue:
+        el.textContent = value
+        el.setAttribute('style', "color:{}; font-size:32;".format(color))
 
-    ## Also update the stepsize input with the current value
-    jq('#stepsize').val(_state['stepsize'])
+    ## Also update the stepsize input with the current value, but
+    ## check that the element does not have focus before doing so
+    ## tp prevent update while user is typing.
+    inp = document.getElementById('stepinput')
+    if inp != document.activeElement:
+        inp.value = _state['stepsize']
 
 
 def handle_stepchange(event):
@@ -94,13 +161,13 @@ def handle_stepchange(event):
     before allowing the submit action to proceed.
     """
     fail_msg = "Step size must be a number between 0 and 10"
-    v = jq('#stepinput').val()
+    v = document.getElementById('stepinput').value
     # Transcrypt float() is buggy, so use some inline JS.
     # See https://github.com/QQuick/Transcrypt/issues/314
     #__pragma__('js','{}','var vj = parseFloat(v); var isfloat = !isNaN(vj);')
     if isfloat and (0.0 <= vj <= 10.0):
         ## It's valid. Send it.
-        jq.post('/setstepsize', { 'stepsize': v })
+        post('/setstepsize', { 'stepsize': v })
         return False
     else:
         alert(fail_msg)
@@ -114,15 +181,18 @@ def start ():
     makeBody()
 
     ## Initialize the readouts
-    global _jq_readouts
-    _jq_readouts = jq('.readout')
-    jq('.readout').css("font-size:12;")
+    nonlocal _readouts
+    _readouts = document.querySelectorAll('.readout')
+    for el in _readouts:
+        el.style.fontSize = '12'
+
 
     ## Bind event handler to step change form
-    jq('#setstep').submit(handle_stepchange)
+    ssform = document.getElementById('setstep')
+    ssform.addEventListener('submit', handle_stepchange)
 
     ## Bind custom event handler to document
-    jq(document).on('state:update', update_readouts)
+    document.addEventListener('state:update', update_readouts)
 
     ## define polling function
     def update ():
@@ -133,3 +203,4 @@ def start ():
     ## Repeat every 0.5 secondss
     window.setInterval (update, 500)
 
+document.addEventListener('DOMContentLoaded', start)

--- a/server.py
+++ b/server.py
@@ -41,7 +41,6 @@ def buildIndexHtml():
     Returns: None
     Raises:  Nothing
     """
-    jquery_url = 'https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js'
 
     linkcolors = list(zip('link visited hover active'.split(),
                           'red green hotpink blue'.split(),))
@@ -50,9 +49,7 @@ def buildIndexHtml():
     head = E('head', None,
              [
               E('style', None, linkcss),
-              E('script', {'src': jquery_url}, []),
               E('script', {'src':'/client.js', 'charset':'UTF-8'}, []),
-              E('script', None, '$(document).ready(client.start)'),
              ])
 
     body = E('body', {'style':{'background-color':'black'}},


### PR DESCRIPTION
There's much that is very good about jQuery.  I'm taking it out because I've concluded that the purpose of demonstrating the capacity of Python + Transcrypt is better served by showing that the native JS DOM calls fit very nicely into the Python idioms. 